### PR TITLE
Pass string to JS

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,16 @@
 use wasm_bindgen::prelude::*;
+use std::ffi::CString;
+use std::os::raw::c_char;
+
+static GAME_NAME: &'static str = "Universal Elevators";
 
 #[wasm_bindgen]
-pub fn add(a: i32, b: i32) -> i32 {
-  return a + b;
+pub fn get_game_name() -> *mut c_char {
+  let s = CString::new(GAME_NAME).unwrap();
+  s.into_raw()
+}
+
+#[wasm_bindgen]
+pub fn get_game_name_len() -> usize {
+  GAME_NAME.len()
 }


### PR DESCRIPTION
In this PR, I implement minimally-viable functionality for passing a string from the Universal Elevators WASM module memory to the JS. This will be generalized and used to pass the game state from the WASM module into JS for display in the DOM.