### PR TITLE
Test build with elevate-lib modules instantiated

### DIFF
--- a/cargo.toml
+++ b/cargo.toml
@@ -17,7 +17,7 @@ categories = ["simulation","visualization"]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cfg-if = { version = "1.0.0" }
+lazy_static = { version = "1.4.0" }
 getrandom = { version = "0.2", features = ["js"] }
 rand = { version = "0.8.5" }
 elevate-lib = { version = "0.1.1" }

--- a/src/game.rs
+++ b/src/game.rs
@@ -19,9 +19,9 @@ impl<T: ElevatorController> ElevatorGame<T> {
     /// ## Example
     ///
     /// ```
-    /// let controller_rng = rand::StdRng::new();
-    /// let my_rng = rand::StdRng::new();
-    /// let my_building: Building = Building::fron(
+    /// let controller_rng = rand::StdRng::from_seed(rand::thread_rng().gen());
+    /// let my_rng = rand::StdRng::from_seed(rand::thread_rng().gen());
+    /// let my_building: Building = Building::from(
     ///     4_usize,
     ///     2_usize,
     ///     0.5_f64,

--- a/src/game.rs
+++ b/src/game.rs
@@ -1,0 +1,61 @@
+//Import standard/external libraries
+use rand::rngs::StdRng;
+use elevate_lib::controller::ElevatorController;
+
+/// # `ElevatorGame` struct
+///
+/// The `ElevatorGame` is the main Universal Elevators game object.
+pub struct ElevatorGame<T: ElevatorController> {
+    pub controller: T,
+    pub counter: i32,
+    rng: StdRng
+}
+
+//Implement the ElevatorGame interface
+impl<T: ElevatorController> ElevatorGame<T> {
+    /// Initialize a new ElevatorGame given an `ElevatorController`
+    /// implementation and a `StdRng` (from the rand library).
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let controller_rng = rand::StdRng::new();
+    /// let my_rng = rand::StdRng::new();
+    /// let my_building: Building = Building::fron(
+    ///     4_usize,
+    ///     2_usize,
+    ///     0.5_f64,
+    ///     5.0_f64,
+    ///     2.5_f64,
+    ///     0.5_f64
+    /// );
+    /// let my_controller: RandomController = RandomController::from(
+    ///     my_building,
+    ///     controller_rng
+    /// );
+    /// let my_game: ElevatorGame<RandomController> = ElevatorGame::from(
+    ///     my_controller,
+    ///     my_rng
+    /// );
+    /// ```
+    pub fn from(controller: T, rng: StdRng) -> ElevatorGame<T> {
+        //Initialize the game
+        ElevatorGame {
+            controller: controller,
+            counter: 0_i32,
+            rng: rng
+        }
+    }
+
+    /// Update the game state, for now this just increments the
+    /// counter.
+    pub fn update_game_state(&mut self) {
+        self.counter += 1_i32;
+    }
+
+    /// Get the game state, for now this just returns a string with
+    /// the counter state.
+    pub fn get_game_state(&self) -> String {
+        format!("{{ 'counter' : {} }}", self.counter)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,45 @@
+mod game;
+
+//Import source modules
+use crate::game::ElevatorGame;
+
+//Import standard/imported libraries
 use wasm_bindgen::prelude::*;
-use std::ffi::CString;
-use std::os::raw::c_char;
+use lazy_static::lazy_static;
+use std::sync::Mutex;
+use rand::Rng;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+use elevate_lib::building::Building;
+use elevate_lib::controller::RandomController;
 
-static GAME_NAME: &'static str = "Universal Elevators";
-
-#[wasm_bindgen]
-pub fn get_game_name() -> *mut c_char {
-  let s = CString::new(GAME_NAME).unwrap();
-  s.into_raw()
+lazy_static! {
+  static ref GAME: Mutex<ElevatorGame<RandomController>> = Mutex::new(
+    ElevatorGame::from(
+      RandomController::from(
+        Building::from(
+          4_usize,
+          2_usize,
+          0.5_f64,
+          5.0_f64,
+          2.5_f64,
+          0.5_f64
+        ),
+        StdRng::from_seed(rand::thread_rng().gen())
+      ),
+      StdRng::from_seed(rand::thread_rng().gen())
+    )
+  );
 }
 
 #[wasm_bindgen]
-pub fn get_game_name_len() -> usize {
-  GAME_NAME.len()
+pub fn update_game_state() {
+  let mut game = GAME.lock().unwrap();
+  game.update_game_state();
+}
+
+#[wasm_bindgen]
+pub fn get_game_state() -> String {
+  let game = GAME.lock().unwrap();
+  game.get_game_state()
 }


### PR DESCRIPTION
In this PR, I establish a working plugin with the `elevate-lib` modules included, giving an early PoC toward a Rust + WASM-based, browser-native elevator simulation package.