### PR TITLE
Initialize universal elevators MVP

### DIFF
--- a/cargo.toml
+++ b/cargo.toml
@@ -21,7 +21,7 @@ lazy_static = { version = "1.4.0" }
 getrandom = { version = "0.2", features = ["js"] }
 rand = { version = "0.8.5" }
 json = { version = "0.12.4" }
-elevate-lib = { version = "0.1.4" }
+elevate-lib = { version = "0.1.9" }
 wasm-bindgen = "0.2.84"
 
 [features]

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,0 +1,36 @@
+use json;
+
+/// # `ElevatorGameInput` struct
+///
+/// The `ElevatorGameInput` struct contains information on the
+/// input provided by the user via the front-end during a time
+/// step.  It is used to update the game state based on user
+/// input.
+pub struct ElevatorGameInput {
+    pub collect_tips: bool,
+    pub append_floor: bool,
+    pub append_elevator: bool
+}
+
+//Implement the ElevatorGameInput interface
+impl ElevatorGameInput {
+    /// Initialize an `ElevatorGameInput` struct explicitly
+    pub fn new(collect_tips: bool, append_floor: bool, append_elevator: bool) -> ElevatorGameInput {
+        ElevatorGameInput {
+            collect_tips: collect_tips,
+            append_floor: append_floor,
+            append_elevator: append_elevator
+        }
+    }
+
+    /// Initialize an `ElevatorGameInput` struct given a JSON
+    /// serialized string containing an input object
+    pub fn from_json(input: String) -> ElevatorGameInput {
+        let input_object = json::parse(&input).unwrap();
+        ElevatorGameInput {
+            collect_tips: input_object["collect_tips"].as_bool().unwrap(),
+            append_floor: input_object["append_floor"].as_bool().unwrap(),
+            append_elevator: input_object["append_elevator"].as_bool().unwrap()
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,11 @@
 mod game;
+mod input;
+mod upgrade;
 
 //Import source modules
 use crate::game::ElevatorGame;
+use crate::input::ElevatorGameInput;
+use crate::upgrade::ElevatorGameUpgrades;
 
 //Import standard/imported libraries
 use wasm_bindgen::prelude::*;
@@ -11,31 +15,37 @@ use rand::Rng;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 use elevate_lib::building::Building;
-use elevate_lib::controller::RandomController;
+use elevate_lib::controller::{RandomController};
 
 lazy_static! {
-  static ref GAME: Mutex<ElevatorGame<RandomController>> = Mutex::new(
+  static ref GAME: Mutex<ElevatorGame> = Mutex::new(
     ElevatorGame::from(
-      RandomController::from(
-        Building::from(
-          4_usize,
-          2_usize,
-          0.5_f64,
-          5.0_f64,
-          2.5_f64,
-          0.5_f64
-        ),
-        StdRng::from_seed(rand::thread_rng().gen())
+      Box::new(
+        RandomController::from_building(
+          Building::from(
+            4_usize,
+            2_usize,
+            0.5_f64,
+            5.0_f64,
+            2.5_f64,
+            0.5_f64
+          )
+        )
       ),
+      ElevatorGameUpgrades::new(),
       StdRng::from_seed(rand::thread_rng().gen())
     )
   );
 }
 
 #[wasm_bindgen]
-pub fn update_game_state() {
+pub fn update_game_state(input: String) {
+  //Parse the input JSON string into an input object
+  let game_input: ElevatorGameInput = ElevatorGameInput::from_json(input);
+
+  //Acquire lock for game state and update given input
   let mut game = GAME.lock().unwrap();
-  game.update_game_state();
+  game.update_game_state(game_input);
 }
 
 #[wasm_bindgen]

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -1,0 +1,250 @@
+/// # `ElevatorGameUpgrades` struct
+///
+/// The `ElevatorGameUpgrades` struct stores each elevator game
+/// upgrade and provides an interface through which one may interact
+/// with the game's upgrades.
+pub struct ElevatorGameUpgrades {
+    pub collect_tips: CollectTipsUpgrade,
+    pub append_floor: AppendFloorUpgrade,
+    pub append_elevator: AppendElevatorUpgrade
+}
+
+impl ElevatorGameUpgrades {
+    /// Initialize the `ElevatorGameUpgrades` struct
+    pub fn new() -> ElevatorGameUpgrades {
+        ElevatorGameUpgrades {
+            collect_tips: CollectTipsUpgrade::new(),
+            append_floor: AppendFloorUpgrade::new(10_f64, 1.5_f64),
+            append_elevator: AppendElevatorUpgrade::new(100_f64, 1.9_f64)
+        }
+    }
+}
+
+/// # `ElevatorGameUpgrade` trait
+///
+/// The `ElevatorGameUpgrade` trait specifies the interface through
+/// which the game interacts with different types of upgrades.
+pub trait ElevatorGameUpgrade {
+    fn get_cost(&self) -> f64;
+
+    fn is_enough(&self, money: f64) -> bool;
+
+    fn get_max_buys(&self) -> usize;
+
+    fn get_name(&self) -> &str;
+
+    fn get_description(&self) -> &str;
+
+    fn buy(&mut self) -> f64;
+}
+
+/// # `CollectTipsUpgrade` struct
+///
+/// The `CollectTipsUpgrade` struct is an upgrade for collecting tips
+/// from the player's building.  It is constantly available throughout
+/// the game.
+pub struct CollectTipsUpgrade {
+    name: String,
+    description: String
+}
+
+impl CollectTipsUpgrade {
+    /// Initialize an `CollectTipsUpgrade` struct
+    pub fn new() -> CollectTipsUpgrade {
+        //Set the name of the upgrade and the description
+        let name = "Collect Tips".to_string();
+        let description = "Collect the tips accumulated by your building".to_string();
+
+        //Initialize and return the CollectTipsUpgrade
+        CollectTipsUpgrade {
+            name: name,
+            description: description
+        }
+    }
+}
+
+impl ElevatorGameUpgrade for CollectTipsUpgrade {
+    /// Get the cost of the upgrade
+    fn get_cost(&self) -> f64 {
+        0.0_f64
+    }
+
+    /// Check if the given amount is less than the cost of the upgrade
+    fn is_enough(&self, money: f64) -> bool {
+        true
+    }
+
+    /// Get the maximum number of floors one can buy
+    fn get_max_buys(&self) -> usize {
+        usize::MAX
+    }
+
+    /// Get the name of the upgrade
+    fn get_name(&self) -> &str {
+        &self.name
+    }
+
+    /// Get the description of the upgrade
+    fn get_description(&self) -> &str {
+        &self.description
+    }
+
+    /// Update the upgrade properties after buying
+    fn buy(&mut self) -> f64 {
+        0.0_f64
+    }
+}
+
+/// # `AppendFloorUpgrade` struct
+///
+/// The `AppendFloorUpgrade` struct is an upgrade for adding a floor
+/// to the player's building.  It is constantly available throughout
+/// the game.
+pub struct AppendFloorUpgrade {
+    base_cost: f64,
+    base_coef: f64,
+    num_buys: usize,
+    max_buys: usize,
+    name: String,
+    description: String
+}
+
+impl AppendFloorUpgrade {
+    /// Initialize an `AppendFloorUpgrade` struct
+    pub fn new(base_cost: f64, base_coef: f64) -> AppendFloorUpgrade {
+        //Set the name of the upgrade and the description
+        let name = "Add Floor".to_string();
+        let description = "Adds a new floor to your building".to_string();
+
+        //Initialize and return the AppendFloorUpgrade
+        AppendFloorUpgrade {
+            base_cost: base_cost,
+            base_coef: base_coef,
+            num_buys: 0_usize,
+            max_buys: usize::MAX,
+            name: name,
+            description: description
+        }
+    }
+}
+
+impl ElevatorGameUpgrade for AppendFloorUpgrade {
+    /// Get the cost of the upgrade
+    fn get_cost(&self) -> f64 {
+        self.base_cost + f64::powf(self.base_coef, self.num_buys as f64)
+    }
+
+    /// Check if the given amount is less than the cost of the upgrade
+    fn is_enough(&self, money: f64) -> bool {
+        money >= self.base_cost + f64::powf(self.base_coef, self.num_buys as f64)
+    }
+
+    /// Get the maximum number of floors one can buy
+    fn get_max_buys(&self) -> usize {
+        self.max_buys
+    }
+
+    /// Get the name of the upgrade
+    fn get_name(&self) -> &str {
+        &self.name
+    }
+
+    /// Get the description of the upgrade
+    fn get_description(&self) -> &str {
+        &self.description
+    }
+
+    /// Update the upgrade properties after buying
+    fn buy(&mut self) -> f64 {
+        //Make sure the upgrade can be purchased
+        if self.num_buys > self.max_buys {
+            panic!("Cannot buy upgrade: {}", self.name);
+        }
+
+        //Calculate the cost before incrementing the num buys
+        let cost: f64 = self.base_cost + f64::powf(self.base_coef, self.num_buys as f64);
+
+        //If it can be purchased, then update the number of buys
+        self.num_buys += 1;
+
+        //Return the cost
+        cost
+    }
+}
+
+/// # `AppendElevatorUpgrade` struct
+///
+/// The `AppendElevatorUpgrade` struct is an upgrade for adding an elevator
+/// to the player's building.  It is constantly available throughout
+/// the game.
+pub struct AppendElevatorUpgrade {
+    base_cost: f64,
+    base_coef: f64,
+    num_buys: usize,
+    max_buys: usize,
+    name: String,
+    description: String
+}
+
+impl AppendElevatorUpgrade {
+    /// Initialize an `AppendElevatorUpgrade` struct
+    pub fn new(base_cost: f64, base_coef: f64) -> AppendElevatorUpgrade {
+        //Set the name of the upgrade and the description
+        let name = "Add Elevator".to_string();
+        let description = "Adds a new elevator to your building".to_string();
+
+        //Initialize and return the AppendElevatorUpgrade
+        AppendElevatorUpgrade {
+            base_cost: base_cost,
+            base_coef: base_coef,
+            num_buys: 0_usize,
+            max_buys: usize::MAX,
+            name: name,
+            description: description
+        }
+    }
+}
+
+impl ElevatorGameUpgrade for AppendElevatorUpgrade {
+    /// Get the cost of the upgrade
+    fn get_cost(&self) -> f64 {
+        self.base_cost + f64::powf(self.base_coef, self.num_buys as f64)
+    }
+
+    /// Check if the given amount is less than the cost of the upgrade
+    fn is_enough(&self, money: f64) -> bool {
+        money >= self.base_cost + f64::powf(self.base_coef, self.num_buys as f64)
+    }
+
+    /// Get the maximum number of floors one can buy
+    fn get_max_buys(&self) -> usize {
+        self.max_buys
+    }
+
+    /// Get the name of the upgrade
+    fn get_name(&self) -> &str {
+        &self.name
+    }
+
+    /// Get the description of the upgrade
+    fn get_description(&self) -> &str {
+        &self.description
+    }
+
+    /// Update the upgrade properties after buying
+    fn buy(&mut self) -> f64 {
+        //Make sure the upgrade can be purchased
+        if self.num_buys > self.max_buys {
+            panic!("Cannot buy upgrade: {}", self.name);
+        }
+
+        //Calculate the cost before incrementing the num buys
+        let cost: f64 = self.base_cost + f64::powf(self.base_coef, self.num_buys as f64);
+
+        //If it can be purchased, then update the number of buys
+        self.num_buys += 1;
+
+        //Return the cost
+        cost
+    }
+}


### PR DESCRIPTION
In this PR I implement various new features to enable an MVP implementation of universal elevators in which the player simply generates tips from their building over time, collects them, and uses them to purchase upgrades for their building.