### PR TITLE
Implement upgrade system for floor & elevator capacity

### DIFF
--- a/cargo.toml
+++ b/cargo.toml
@@ -21,7 +21,7 @@ lazy_static = { version = "1.4.0" }
 getrandom = { version = "0.2", features = ["js"] }
 rand = { version = "0.8.5" }
 json = { version = "0.12.4" }
-elevate-lib = { version = "0.1.9" }
+elevate-lib = { version = "0.1.0-202403171545+1.0.0-alpha.1" }
 wasm-bindgen = "0.2.84"
 
 [features]

--- a/src/game.rs
+++ b/src/game.rs
@@ -79,15 +79,32 @@ impl ElevatorGame {
             if input.append_floor && self.upgrades.append_floor.is_enough(self.tips) {
                 let cost: f64 = self.upgrades.append_floor.buy();
                 self.tips -= cost;
-                building.append_floor();
+                let capacity: usize = building.floors[0].capacity;
+                building.append_floor(capacity);
             }
             if input.append_elevator && self.upgrades.append_elevator.is_enough(self.tips) {
                 let cost: f64 = self.upgrades.append_elevator.buy();
                 self.tips -= cost;
+                let capacity: usize = building.elevators[0].capacity;
                 let energy_up: f64 = building.elevators[0].energy_up;
                 let energy_down: f64 = building.elevators[0].energy_down;
                 let energy_coef: f64 = building.elevators[0].energy_coef;
-                building.append_elevator(energy_up, energy_down, energy_coef);
+                building.append_elevator(capacity, energy_up, energy_down, energy_coef);
+            }
+
+            //If the player added capacity to their floors or elevators,
+            //then update their capacities
+            if input.add_floor_capacity && self.upgrades.add_floor_capacity.is_enough(self.tips) {
+                let cost: f64 = self.upgrades.add_floor_capacity.buy();
+                self.tips -= cost;
+                let current_capacity: usize = building.floors[0].capacity;
+                building.floors.update_capacities(current_capacity + 100);
+            }
+            if input.add_elevator_capacity && self.upgrades.add_elevator_capacity.is_enough(self.tips) {
+                let cost: f64 = self.upgrades.add_elevator_capacity.buy();
+                self.tips -= cost;
+                let current_capacity: usize = building.elevators[0].capacity;
+                building.elevators.update_capacities(current_capacity + 10);
             }
 
             //Generate people arriving and leaving
@@ -152,6 +169,7 @@ impl ElevatorGame {
             let _ = game_state["floors"].push(
                 object!{
                     num_people: floor.get_num_people(),
+                    capacity: floor.capacity,
                     are_people_waiting: floor.are_people_waiting()
                 }
             );
@@ -163,6 +181,7 @@ impl ElevatorGame {
             let _ = game_state["elevators"].push(
                 object!{
                     num_people: elevator.get_num_people(),
+                    capacity: elevator.capacity,
                     floor_on: elevator.floor_on
                 }
             );

--- a/src/input.rs
+++ b/src/input.rs
@@ -9,17 +9,22 @@ use json;
 pub struct ElevatorGameInput {
     pub collect_tips: bool,
     pub append_floor: bool,
-    pub append_elevator: bool
+    pub append_elevator: bool,
+    pub add_elevator_capacity: bool,
+    pub add_floor_capacity: bool
 }
 
 //Implement the ElevatorGameInput interface
 impl ElevatorGameInput {
     /// Initialize an `ElevatorGameInput` struct explicitly
-    pub fn new(collect_tips: bool, append_floor: bool, append_elevator: bool) -> ElevatorGameInput {
+    pub fn new(collect_tips: bool, append_floor: bool, append_elevator: bool,
+               add_elevator_capacity: bool, add_floor_capacity: bool) -> ElevatorGameInput {
         ElevatorGameInput {
             collect_tips: collect_tips,
             append_floor: append_floor,
-            append_elevator: append_elevator
+            append_elevator: append_elevator,
+            add_elevator_capacity: add_elevator_capacity,
+            add_floor_capacity: add_floor_capacity
         }
     }
 
@@ -30,7 +35,9 @@ impl ElevatorGameInput {
         ElevatorGameInput {
             collect_tips: input_object["collect_tips"].as_bool().unwrap(),
             append_floor: input_object["append_floor"].as_bool().unwrap(),
-            append_elevator: input_object["append_elevator"].as_bool().unwrap()
+            append_elevator: input_object["append_elevator"].as_bool().unwrap(),
+            add_elevator_capacity: input_object["add_elevator_capacity"].as_bool().unwrap(),
+            add_floor_capacity: input_object["add_floor_capacity"].as_bool().unwrap()
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,8 @@ lazy_static! {
             4_usize,
             2_usize,
             0.5_f64,
+            100_usize,
+            10_usize,
             5.0_f64,
             2.5_f64,
             0.5_f64

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -6,7 +6,9 @@
 pub struct ElevatorGameUpgrades {
     pub collect_tips: CollectTipsUpgrade,
     pub append_floor: AppendFloorUpgrade,
-    pub append_elevator: AppendElevatorUpgrade
+    pub append_elevator: AppendElevatorUpgrade,
+    pub add_floor_capacity: AddFloorCapacityUpgrade,
+    pub add_elevator_capacity: AddElevatorCapacityUpgrade
 }
 
 impl ElevatorGameUpgrades {
@@ -15,7 +17,9 @@ impl ElevatorGameUpgrades {
         ElevatorGameUpgrades {
             collect_tips: CollectTipsUpgrade::new(),
             append_floor: AppendFloorUpgrade::new(10_f64, 1.5_f64),
-            append_elevator: AppendElevatorUpgrade::new(100_f64, 1.9_f64)
+            append_elevator: AppendElevatorUpgrade::new(100_f64, 1.9_f64),
+            add_floor_capacity: AddFloorCapacityUpgrade::new(10_f64, 1.1_f64),
+            add_elevator_capacity: AddElevatorCapacityUpgrade::new(10_f64, 1.1_f64)
         }
     }
 }
@@ -206,6 +210,160 @@ impl AppendElevatorUpgrade {
 }
 
 impl ElevatorGameUpgrade for AppendElevatorUpgrade {
+    /// Get the cost of the upgrade
+    fn get_cost(&self) -> f64 {
+        self.base_cost + f64::powf(self.base_coef, self.num_buys as f64)
+    }
+
+    /// Check if the given amount is less than the cost of the upgrade
+    fn is_enough(&self, money: f64) -> bool {
+        money >= self.base_cost + f64::powf(self.base_coef, self.num_buys as f64)
+    }
+
+    /// Get the maximum number of floors one can buy
+    fn get_max_buys(&self) -> usize {
+        self.max_buys
+    }
+
+    /// Get the name of the upgrade
+    fn get_name(&self) -> &str {
+        &self.name
+    }
+
+    /// Get the description of the upgrade
+    fn get_description(&self) -> &str {
+        &self.description
+    }
+
+    /// Update the upgrade properties after buying
+    fn buy(&mut self) -> f64 {
+        //Make sure the upgrade can be purchased
+        if self.num_buys > self.max_buys {
+            panic!("Cannot buy upgrade: {}", self.name);
+        }
+
+        //Calculate the cost before incrementing the num buys
+        let cost: f64 = self.base_cost + f64::powf(self.base_coef, self.num_buys as f64);
+
+        //If it can be purchased, then update the number of buys
+        self.num_buys += 1;
+
+        //Return the cost
+        cost
+    }
+}
+
+/// # `AddFloorCapacityUpgrade` struct
+///
+/// The `AddFloorCapacityUpgrade` struct is an upgrade for adding capacity
+/// to the floors of the player's buildings.  It is constantly available
+/// throughout the game.
+pub struct AddFloorCapacityUpgrade {
+    base_cost: f64,
+    base_coef: f64,
+    num_buys: usize,
+    max_buys: usize,
+    name: String,
+    description: String
+}
+
+impl AddFloorCapacityUpgrade {
+    /// Initialize an `AddFloorCapacityUpgrade` struct
+    pub fn new(base_cost: f64, base_coef: f64) -> AddFloorCapacityUpgrade {
+        //Set the name of the upgrade and the description
+        let name = "Add Floor Capacity".to_string();
+        let description = "Adds more capacity to your floors".to_string();
+
+        //Initialize and return the AddFloorCapacityUpgrade
+        AddFloorCapacityUpgrade {
+            base_cost: base_cost,
+            base_coef: base_coef,
+            num_buys: 0_usize,
+            max_buys: usize::MAX,
+            name: name,
+            description: description
+        }
+    }
+}
+
+impl ElevatorGameUpgrade for AddFloorCapacityUpgrade {
+    /// Get the cost of the upgrade
+    fn get_cost(&self) -> f64 {
+        self.base_cost + f64::powf(self.base_coef, self.num_buys as f64)
+    }
+
+    /// Check if the given amount is less than the cost of the upgrade
+    fn is_enough(&self, money: f64) -> bool {
+        money >= self.base_cost + f64::powf(self.base_coef, self.num_buys as f64)
+    }
+
+    /// Get the maximum number of floors one can buy
+    fn get_max_buys(&self) -> usize {
+        self.max_buys
+    }
+
+    /// Get the name of the upgrade
+    fn get_name(&self) -> &str {
+        &self.name
+    }
+
+    /// Get the description of the upgrade
+    fn get_description(&self) -> &str {
+        &self.description
+    }
+
+    /// Update the upgrade properties after buying
+    fn buy(&mut self) -> f64 {
+        //Make sure the upgrade can be purchased
+        if self.num_buys > self.max_buys {
+            panic!("Cannot buy upgrade: {}", self.name);
+        }
+
+        //Calculate the cost before incrementing the num buys
+        let cost: f64 = self.base_cost + f64::powf(self.base_coef, self.num_buys as f64);
+
+        //If it can be purchased, then update the number of buys
+        self.num_buys += 1;
+
+        //Return the cost
+        cost
+    }
+}
+
+/// # `AddElevatorCapacityUpgrade` struct
+///
+/// The `AddElevatorCapacityUpgrade` struct is an upgrade for adding capacity
+/// to the floors of the player's buildings.  It is constantly available
+/// throughout the game.
+pub struct AddElevatorCapacityUpgrade {
+    base_cost: f64,
+    base_coef: f64,
+    num_buys: usize,
+    max_buys: usize,
+    name: String,
+    description: String
+}
+
+impl AddElevatorCapacityUpgrade {
+    /// Initialize an `AddElevatorCapacityUpgrade` struct
+    pub fn new(base_cost: f64, base_coef: f64) -> AddElevatorCapacityUpgrade {
+        //Set the name of the upgrade and the description
+        let name = "Add Elevator Capacity".to_string();
+        let description = "Adds more capacity to your elevators".to_string();
+
+        //Initialize and return the AddElevatorCapacityUpgrade
+        AddElevatorCapacityUpgrade {
+            base_cost: base_cost,
+            base_coef: base_coef,
+            num_buys: 0_usize,
+            max_buys: usize::MAX,
+            name: name,
+            description: description
+        }
+    }
+}
+
+impl ElevatorGameUpgrade for AddElevatorCapacityUpgrade {
     /// Get the cost of the upgrade
     fn get_cost(&self) -> f64 {
         self.base_cost + f64::powf(self.base_coef, self.num_buys as f64)


### PR DESCRIPTION
In this PR, I implement a system within the WASM module to
- Report the current floor & elevator capacity
- Accept input on upgrading the floor & elevator capacity
- Actually upgrade the floor & elevator capacity
- Increment the price of these upgrades
- Check whether the player has enough money for the upgrades